### PR TITLE
feat(styles): update color scheme and texts for better visual hierarchy

### DIFF
--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -12,7 +12,7 @@ export default async function Home() {
     <div className="bg-grey-bg rounded-lg h-full w-full overflow-hidden overflow-y-auto">
       <Header>
         <div className="mb-2">
-          <h1 className="text-grey text-3xl font-semibold">
+          <h1 className="text-grey-titles text-4xl font-semibold">
             Welcome Back
           </h1>
           <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 gap-3 mt-4">
@@ -22,11 +22,11 @@ export default async function Home() {
       </Header>
       <div className="mt-2 mb-7 px-6">
         <div className="flex justify-between items-center">
-          <h1 className="text-grey text-2xl font-semibold">
+          <h1 className="text-grey-titles text-2xl font-semibold">
             Newest songs
           </h1>
         </div>
-        <div className="text-grey-light">
+        <div className="text-grey-body">
           List of Songs!
         </div>
         <PageContent songs={songs} />

--- a/app/liked/components/LikedContent.tsx
+++ b/app/liked/components/LikedContent.tsx
@@ -32,7 +32,7 @@ const LikedContent: React.FC<LikedContentProps> = ({ songs }) => {
                 flex-col 
                 gap-y-2 
                 w-full px-6 
-                text-grey"
+                text-grey-body"
             >
                 No liked songs.
             </div>

--- a/app/liked/page.tsx
+++ b/app/liked/page.tsx
@@ -31,11 +31,11 @@ const Liked = async () => {
                             />
                         </div>
                         <div className="flex flex-col gap-y-2 mt-4 md:mt-0">
-                            <p className="hidden md:block font-semibold text-sm">
+                            <p className="hidden md:block font-semibold text-sm text-grey-body">
                                 Playlist
                             </p>
                             <h1 className="
-                                text-grey
+                                text-grey-titles
                                 text-4xl 
                                 sm:text-5xl 
                                 lg:text-7xl 

--- a/app/search/components/SearchContent.tsx
+++ b/app/search/components/SearchContent.tsx
@@ -22,7 +22,7 @@ const SearchContent: React.FC<SearchContentProps> = ({ songs }) => {
                 gap-y-2 
                 w-full 
                 px-6 
-                text-grey-light "
+                text-grey-body "
             >
                 No songs found.
             </div>

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -25,7 +25,7 @@ const Search = async ({ searchParams }: SearchProps) => {
         >
             <Header className="from-bg-neutral-900">
                 <div className="mb-2 flex flex-col gap-y-6">
-                    <h1 className="text-grey text-3xl font-semibold">
+                    <h1 className="text-grey-titles text-3xl font-semibold">
                         Search
                     </h1>
                     <SearchInput />

--- a/components/AuthModal.tsx
+++ b/components/AuthModal.tsx
@@ -47,8 +47,8 @@ const AuthModal = () => {
                     variables: {
                         default: {
                             colors: {
-                                brand: '#EE732F',
-                                brandAccent: '#EE732F',
+                                brand: '#4682B4',
+                                brandAccent: '#4682B4',
                                 defaultButtonBackgroundHover: '#3a383f',
                                 defaultButtonBackground: '#303134',
                                 defaultButtonText: 'white',

--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -16,7 +16,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(({
             className={twMerge(
                 `w-full 
                 rounded-md
-                bg-orange
+                bg-blue
                 border
                 border-transparent
                 px-4

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -50,13 +50,13 @@ const Header: React.FC<HeaderProps> = ({ children, className }) => {
                         onClick={() => router.back()}
                         className="flex items-center justify-center hover:opacity-75 transition"
                     >
-                        <RxCaretLeft className="text-grey" size={35} />
+                        <RxCaretLeft className="text-grey-titles" size={35} />
                     </button>
                     <button
                         onClick={() => router.forward()}
                         className="flex items-center justify-center hover:opacity-75 transition"
                     >
-                        <RxCaretRight className="text-grey" size={35} />
+                        <RxCaretRight className="text-grey-titles" size={35} />
                     </button>
                 </div>
                 <div className="flex md:hidden gap-x-2 items-center">
@@ -72,13 +72,13 @@ const Header: React.FC<HeaderProps> = ({ children, className }) => {
                         <div className="flex gap-x-4 items-center">
                             <Button
                                 onClick={handleLogout}
-                                className="bg-orange px-6 py-2"
+                                className="bg-blue px-6 py-2"
                             >
                                 Logout
                             </Button>
                             <Button
                                 onClick={() => router.push('/account')}
-                                className="bg-orange border-r-4"
+                                className="bg-blue border-r-4"
                             >
                                 <FaUserAlt />
                             </Button>
@@ -86,10 +86,10 @@ const Header: React.FC<HeaderProps> = ({ children, className }) => {
                     ) : (
                         <>
                             <div>
-                                <Button onClick={authModal.onOpen} className="bg-transparent text-grey font-medium">Sign Up!</Button>
+                                <Button onClick={authModal.onOpen} className="bg-transparent text-grey-titles font-medium">Sign Up!</Button>
                             </div>
                             <div>
-                                <Button onClick={authModal.onOpen} className="bg-orange px-4 py-2">Log in!</Button>
+                                <Button onClick={authModal.onOpen} className="bg-blue px-4 py-2">Log in!</Button>
                             </div>
                         </>
                     )}

--- a/components/Library.tsx
+++ b/components/Library.tsx
@@ -41,10 +41,10 @@ const Library: React.FC<LibraryProps> = ({ songs }) => {
             <div className="flex items-center justify-between px-5 pt-4">
                 <div className="inline-flex items-center gap-x-2">
                     <TbPlaylist size={26} className="text-grey" />
-                    <p className="text-grey font-medium text-md">Your Library</p>
+                    <p className="text-grey-title font-medium text-md">Your Library</p>
                 </div>
                 <AiOutlinePlus
-                    className="text-grey cursor-pointer hover:text-orange transition"
+                    className="text-grey cursor-pointer hover:text-blue transition"
                     onClick={onClick}
                     size={20}
                 />

--- a/components/LikeButton.tsx
+++ b/components/LikeButton.tsx
@@ -88,7 +88,7 @@ const LikeButton: React.FC<LikeButtonProps> = ({ songId }) => {
             transition"
             onClick={handleLike}
         >
-            <Icon color={isLiked ? '#ee732f' : 'grey'} size={25} />
+            <Icon color={isLiked ? '#FF6B6B' : 'grey'} size={25} />
         </button>
     );
 }

--- a/components/ListItem.tsx
+++ b/components/ListItem.tsx
@@ -52,7 +52,7 @@ const ListItem: React.FC<ListItemProps> = ({ image, name, href }) => {
                     alt="Image"
                 />
             </div>
-            <p className="font-medium truncate py-5 text-grey">
+            <p className="font-medium truncate py-5 text-grey-body">
                 {name}
             </p>
             <div
@@ -64,7 +64,7 @@ const ListItem: React.FC<ListItemProps> = ({ image, name, href }) => {
                     flex 
                     items-center 
                     justify-center 
-                    bg-orange
+                    bg-blue
                     p-4 
                     drop-shadow-md 
                     right-5

--- a/components/MediaItem.tsx
+++ b/components/MediaItem.tsx
@@ -54,8 +54,8 @@ const MediaItem: React.FC<MediaItemProps> = ({ data, onClick }) => {
                 />
             </div>
             <div className="flex flex-col gap-y-1 overflow-hidden">
-                <p className="text-grey truncate">{data.title}</p>
-                <p className="text-grey-light text-sm truncate">
+                <p className="text-grey-title truncate">{data.title}</p>
+                <p className="text-grey-body text-sm truncate">
                     By {data.author}
                 </p>
             </div>

--- a/components/PlayButton.tsx
+++ b/components/PlayButton.tsx
@@ -10,7 +10,7 @@ const PlayButton = () => {
             flex 
             items-center 
             justify-center 
-            bg-orange 
+            bg-blue 
             p-4 
             drop-shadow-md 
             translate

--- a/components/SidebarItem.tsx
+++ b/components/SidebarItem.tsx
@@ -30,12 +30,12 @@ const SidebarItem: React.FC<SidebarItemProps> = ({
                 text-md
                 font-medium
                 cursor-pointer
-                hover:text-orange           
+                hover:text-blue           
                 transition
-                text-grey
+                text-grey-body
                 px-2
-                py-1`,
-                active && "text-orange bg-white rounded-md ",
+                `,
+                active && "text-blue border-l-2 border-l-blue",
             )}
         >
             <Icon size={26} />

--- a/components/SongItem.tsx
+++ b/components/SongItem.tsx
@@ -32,6 +32,7 @@ const SongItem: React.FC<SongItemProps> = ({ data, onClick }) => {
                 cursor-pointer 
                 hover:bg-grey-soft/30
                 transition 
+                shadow-sm
                 p-3"
         >
             <div
@@ -51,11 +52,11 @@ const SongItem: React.FC<SongItemProps> = ({ data, onClick }) => {
                 />
             </div>
             <div className="flex flex-col items-start w-full pt-4 gap-y-1">
-                <p className="font-semibold truncate w-full">
+                <p className="text-lg font-semibold truncate w-full">
                     {data.title}
                 </p>
                 <p className="
-                    text-neutral-400 
+                    text-grey-body 
                     text-sm 
                     pb-4 
                     w-full 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -11,14 +11,15 @@ const config: Config = {
       colors: {
         grey: {
           DEFAULT: "#3A383F",
-          sidebar: "#F2F1F5",
-          light: "#A6A6AC",
-          bg: "#F9F9F9",
-          soft: "#d8d8d8",
-          input: "#e8f0fe"
+          sidebar: "#F2F2F2",
+          bg: "#F7F7F7",
+          soft: "#D3E1E6",
+          body: "#424242",
+          titles: "#303030",
+          light: "#757575",
         },
-        orange: {
-          DEFAULT: "#EE732F",
+        blue: {
+          DEFAULT: "#4682B4",
         },
       },
     },


### PR DESCRIPTION
- Change primary brand color from orange to blue and secondary brand color to match.
- Increase title font sizes for a clearer visual hierarchy.
- Update text color classes to distinguish titles, body text, and inactive elements.
- Adjust shadow and hover styles for consistency with new color scheme.
- Edit active sidebar item style for better visual indication of active state.

This commit overhauls the UI's color scheme for improved aesthetics and usability.